### PR TITLE
[BUGFIX] Correct Unbounded dispersion placement

### DIFF
--- a/insilicosv/simulate.py
+++ b/insilicosv/simulate.py
@@ -294,6 +294,7 @@ class SVSimulator:
                                                     blacklist_regions=blacklist_regions, roi_length=roi_length, total_length=total_length)
             num_tries += 1
         if breakend is None:
+            # The breakend failed to be assign by random sampling, the actual available region has to be checked.
             return self.get_breakend_from_regions(containing_region=containing_region, avoid_chrom=avoid_chrom,
                                              blacklist_regions=blacklist_regions, roi_length=roi_length, total_length=total_length)
         return breakend, ref_roi
@@ -331,7 +332,11 @@ class SVSimulator:
                 ref_intervals = []
                 overlaps = tree.overlap(containing_region.start, containing_region.end)
                 for overlap in overlaps:
-                    ref_intervals.append(overlap.chop(containing_region.start, containing_region.end))
+                    # Chop the intervals overlapping the containing region
+                    min_interval = min(overlap.begin, containing_region.start)
+                    max_interval = max(overlap.end, containing_region.end)
+                    ref_intervals.append(Interval(begin=min_interval, end=max_interval,
+                                                  data=overlap.data.replace(start=min_interval, end=max_interval)))
             for interval in ref_intervals:
                 # Remove the intervals that are too small or too close to the end of the chromosome
                 if interval.length() < roi_length: continue
@@ -557,7 +562,7 @@ class SVSimulator:
                         avoid_chrom = None
                         bound = if_not_none(min_dist[pos], 0)
                         if in_anchor:
-                            # we add a brakend position between the last breakend placed and the end of the anchor roi
+                            # we add a breakend position between the last breakend placed from th same SV, and the end of the anchor roi
                             # +1 to ensure the previous symbol in the anchor doesn't have a length of 0
                             left_bound = roi.start +1
                             # -1 to ensure the current symbol doesn't have a length of 0


### PR DESCRIPTION
Correct an issue when an unbounded dispersion could not be placed randomly in the allocated number of tries. Now the available regions are computed correctly without error.